### PR TITLE
Remove realpath call because it is incompatible with streamwrappers

### DIFF
--- a/btree.php
+++ b/btree.php
@@ -460,7 +460,6 @@ final class btree
     public static function open($filename)
     {
         if (!($handle = @fopen($filename, 'a+b'))) return FALSE;
-        if (($filename = realpath($filename)) === FALSE) return FALSE;
 
         // write default node if neccessary
         if (fseek($handle, 0, SEEK_END) === -1) {


### PR DESCRIPTION
The `realpath` function doesn't work with streamwrappers,
@see [https://github.com/mikey179/vfsStream/wiki/Known-Issues](https://github.com/mikey179/vfsStream/wiki/Known-Issues).